### PR TITLE
Fix the "utils.isSelectionInTable" bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function EditTable(opts = {}) {
         var parentBlock = state.document.getParent(state.startBlock.key)
    
         // Only handle events in cells
-        return parentBlock.type == opts.typeCell;
+        return parentBlock.type == opts.typeCell || parentBlock.type == opts.typeRow;
     }
 
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,10 +42,10 @@ function EditTable(opts = {}) {
      */
     function isSelectionInTable(state) {
         if (!state.selection.startKey) return false;
-        const block = findBlock(opts.typeCell, state, state.startBlock);
-
+        var parentBlock = state.document.getParent(state.startBlock.key)
+   
         // Only handle events in cells
-        return block != null;
+        return parentBlock.type == opts.typeCell;
     }
 
     /**


### PR DESCRIPTION
![test](https://media.giphy.com/media/TH4IotC1pvQYM/giphy.gif "GIF")

In your fork example, `utils.isSelectionInTable` like above GIF,  is not working. 

This PR is fix it. 